### PR TITLE
Fix null assert crash, add spacing, and replaced gesture detector with material button

### DIFF
--- a/tag_view/lib/src/tagview.dart
+++ b/tag_view/lib/src/tagview.dart
@@ -38,11 +38,7 @@ class _TagView extends State<TagView> {
               shape: const RoundedRectangleBorder(
                   borderRadius: BorderRadius.all(Radius.circular(20))),
               color: widget.tagBackgroundColor,
-              onPressed: () {
-                if (widget.onClick != null) {
-                  widget.onClick!(widget.tags.indexOf(i));
-                }
-              },
+              onPressed: () => widget.onClick?.call(widget.tags.indexOf(i)),
               child: Wrap(
                 crossAxisAlignment: WrapCrossAlignment.center,
                 children: [
@@ -60,11 +56,8 @@ class _TagView extends State<TagView> {
                   Visibility(
                     visible: widget.isEnableDelete,
                     child: InkWell(
-                      onTap: () {
-                        if (widget.onDelete != null) {
-                          widget.onDelete!(widget.tags.indexOf(i));
-                        }
-                      },
+                      onTap: () =>
+                          widget.onDelete?.call(widget.tags.indexOf(i)),
                       child: const Icon(
                         Icons.close_outlined,
                         color: Colors.white,

--- a/tag_view/lib/src/tagview.dart
+++ b/tag_view/lib/src/tagview.dart
@@ -7,14 +7,23 @@ class TagView extends StatefulWidget {
   Color tagBackgroundColor;
   ValueChanged? onDelete;
   ValueChanged? onClick;
+  final double spacing;
 
   int deletePos = -1;
 
-  TagView(this.tags, {this.isEnableDelete = false, this.tagBackgroundColor = Colors.blueAccent, this.onDelete, this.onClick}) {}
+  TagView(
+    this.tags, {
+    super.key,
+    this.isEnableDelete = false,
+    this.tagBackgroundColor = Colors.blueAccent,
+    this.onDelete,
+    this.onClick,
+    this.spacing = 0,
+  }) {}
 
   @override
   State<StatefulWidget> createState() {
-  return _TagView();
+    return _TagView();
   }
 }
 
@@ -22,46 +31,51 @@ class _TagView extends State<TagView> {
   @override
   Widget build(BuildContext context) {
     return Wrap(
+      spacing: widget.spacing,
       children: widget.tags
-          .map((i) =>
-          GestureDetector(
-            onTap: () {
-              widget.onClick!(widget.tags.indexOf(i));
-            },
-            child: Container(
-                margin: EdgeInsets.all(5),
-                padding: const EdgeInsets.only(
-                    top: 5.0, bottom: 5.0, left: 10, right: 5),
-                decoration: BoxDecoration(
-                    color: widget.tagBackgroundColor,
-                    borderRadius: BorderRadius.all(Radius.circular(20))),
-                child: Wrap(
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  children: [
-                    Text(i,
-                        style: TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold,
-                            fontSize: 14)),
-                    SizedBox(
-                      width: 2,
+          .map(
+            (i) => MaterialButton(
+              shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(20))),
+              color: widget.tagBackgroundColor,
+              onPressed: () {
+                if (widget.onClick != null) {
+                  widget.onClick!(widget.tags.indexOf(i));
+                }
+              },
+              child: Wrap(
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  Text(
+                    i,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 14,
                     ),
-                    Visibility(
-                      visible: widget.isEnableDelete,
-                      child: InkWell(
-                        onTap: () {
+                  ),
+                  const SizedBox(
+                    width: 2,
+                  ),
+                  Visibility(
+                    visible: widget.isEnableDelete,
+                    child: InkWell(
+                      onTap: () {
+                        if (widget.onDelete != null) {
                           widget.onDelete!(widget.tags.indexOf(i));
-                        },
-                        child: Icon(
-                          Icons.close_outlined,
-                          color: Colors.white,
-                          size: 20,
-                        ),
+                        }
+                      },
+                      child: const Icon(
+                        Icons.close_outlined,
+                        color: Colors.white,
+                        size: 20,
                       ),
-                    )
-                  ],
-                )),
-          ))
+                    ),
+                  )
+                ],
+              ),
+            ),
+          )
           .toList(),
     );
   }


### PR DESCRIPTION
    feedback (adds a splash effect, removes
    margins in favor of spacing and swaps for
    spacing etc.)
instead of gesture detector now uses
    MaterialButton,
checks null on callbacks before running them to
    fix null errors.